### PR TITLE
Add Like/Unlike Functionality for Ads

### DIFF
--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -92,12 +92,6 @@ class ProfileModelTest(TestCase):
         self.assertNotEqual(original_updated_at, profile.updated_at)
 
 
-from django.test import TestCase
-from django.urls import reverse
-from django.contrib.auth.models import User
-from .forms import UserRegistrationForm, ProfileForm
-from .models import Profile
-
 class UserRegistrationTests(TestCase):
 
     def test_successful_registration(self):

--- a/ads/templates/ads/ad_detail.html
+++ b/ads/templates/ads/ad_detail.html
@@ -11,76 +11,98 @@
 
     <div class="mt-6">
         <img src="{{ ad.image.url }}" alt="{{ ad.title }}" class="w-full h-auto max-h-[500px] object-contain rounded-lg shadow-md">
-    </div>    
+    </div>
 
-    <p class="mt-6 text-gray-600">{{ ad.description }}</p>
+    <div class="relative bg-gray-100 p-6 rounded-lg mt-4 shadow-md">
+        <div class="absolute top-2 right-2">
+            {% if user.is_authenticated %}
+                <div x-data="likeComponent({{ user_has_liked|lower }}, {{ ad.total_likes }}, '{{ csrf_token }}')" class="flex flex-col items-center justify-end text-right">
+                    <a @click="likeAd('{{ ad.category.slug }}', '{{ ad.slug }}')" class="inline-flex items-center justify-end p-2 rounded-full hover:bg-gray-200 transition duration-200">
+                        <template x-if="liked">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 text-red-500" fill="currentColor" viewBox="0 0 24 24" stroke="none">
+                                <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
+                            </svg>
+                        </template>
+                        <template x-if="!liked">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z" />
+                            </svg>
+                        </template>
+                    </a>
+                    <p class="text-sm text-gray-600">
+                        <span x-text="totalLikes"></span>
+                    </p>
+                </div>
+            {% endif %}
+            {% if ad.user == user %}
+                <div class="flex space-x-2">
+                    <a href="{% url 'ads:ad_edit' category_slug=ad.category.slug ad_slug=ad.slug %}" class="p-2" onmouseover="this.setAttribute('title', 'Edit Ad')" onmouseout="this.removeAttribute('title')">
+                        <i class="fas fa-edit text-gray-600"></i>
+                    </a>
+                    <a href="{% url 'ads:ad_delete' category_slug=ad.category.slug ad_slug=ad.slug %}" class="p-2" onmouseover="this.setAttribute('title', 'Delete Ad')" onmouseout="this.removeAttribute('title') onclick="return confirm('Are you sure you want to delete this Ad?');"">
+                        <i class="fas fa-trash-alt text-gray-600"></i>
+                    </a>
+                    <form action="{% url 'ads:toggle_contact_info' category_slug=ad.category.slug ad_slug=ad.slug %}" method="POST" id="toggle-contact-form" class="flex items-center p-2">
+                        {% csrf_token %}
+                        <input type="hidden" name="ad_id" value="{{ ad.id }}">
+                        <input type="hidden" name="show_contact_info" value="{{ ad.show_contact_info|yesno:'True,False' }}">
 
-    <p class="mt-2 text-gray-600"><strong>Location:</strong> {{ ad.location }}</p>
-
-    {% if ad.category.name == 'Rentals' or ad.category.name == 'Jobs' %}
-        <p class="mt-2 text-gray-600"><strong>Monthly Rate:</strong> ₹{{ ad.price }} / month</p>
-    {% else %}
-        <p class="mt-2 text-gray-600"><strong>Price:</strong> ₹{{ ad.price }}</p>
-    {% endif %}
-    
-
-    <p class="mt-2 text-gray-600"><strong>Posted on:</strong> {{ ad.created_at|date:"F j, Y" }}</p>
-
-    <p class="mt-2 text-gray-600"><strong>Posted by:</strong> {{ ad.user.username }}</p>
-
-    {% if ad.show_contact_info %}
-    <p class="mt-4 text-gray-600"><strong>Contact Info:</strong> {{ ad.contact_info }}</p>
-    {% endif %}
-
-    {% if ad.category.name == 'Events' or ad.category.name == 'Classes' %}
-        <p class="mt-2 text-gray-600"><strong>Event Start:</strong> {{ ad.event_start_date }}</p>
-        <p class="mt-2 text-gray-600"><strong>Event End:</strong> {{ ad.event_end_date }}</p>
-    {% endif %}
-
-    {% if user.is_authenticated %}
-        <div x-data="likeComponent({{ user_has_liked|lower }}, {{ ad.total_likes }}, '{{ csrf_token }}')" class="flex flex-col items-center justify-end text-right">
-        
-            <a @click="likeAd('{{ ad.category.slug }}', '{{ ad.slug }}')" class="inline-flex items-center justify-end mt-2 p-2 rounded-full hover:bg-gray-200 transition duration-200">
-                
-                <template x-if="liked">
-                    <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 text-red-500" fill="currentColor" viewBox="0 0 24 24" stroke="none">
-                        <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
-                    </svg>
-                </template>
-                <template x-if="!liked">
-                    <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z" />
-                    </svg>
-                </template>
-
-            </a>
-            
-            <p class="text-sm text-gray-600">
-                <span x-text="totalLikes"></span>
-            </p>
+                        <span class="cursor-pointer" onclick="document.getElementById('toggle-contact-form').submit()">
+                            {% if ad.show_contact_info %}
+                                <i class="fas fa-user-slash text-red-500" title="Hide Contact Info"></i> <!-- Icon for hiding contact info -->
+                            {% else %}
+                                <i class="fas fa-user text-gray-600" title="Show Contact Info"></i> <!-- Icon for showing contact info -->
+                            {% endif %}
+                        </span>
+                    </form>
+                </div>
+            {% endif %}
         </div>
 
-        {% if ad.user == user %}
-            <div class="mt-6 flex justify-around">
-                <a href="{% url 'ads:ad_edit' category_slug=ad.category.slug ad_slug=ad.slug %}" class="p-3 rounded-lg bg-red-500 text-white hover:bg-red-600 transition duration-200">
-                    <i class="fas fa-edit"></i> Edit
-                </a>
+        <h2 class="text-lg font-bold text-gray-800 mt-4">Description:</h2>
+        <p class="mt-2 text-gray-600">{{ ad.description }}</p>
 
-                <a href="{% url 'ads:ad_delete' category_slug=ad.category.slug ad_slug=ad.slug %}" class="p-3 rounded-lg bg-red-500 text-white hover:bg-red-600 transition duration-200">
-                    <i class="fas fa-trash-alt"></i> Delete
-                </a>
+        <hr class="my-4">
+
+        <h2 class="text-lg font-bold text-gray-800">Details:</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-2">
+            <div>
+                <p class="mt-2 text-gray-600"><strong>Location:</strong> {{ ad.location }}</p>
+                {% if ad.category.name == 'Rentals' or ad.category.name == 'Jobs' %}
+                    <p class="mt-2 text-gray-600"><strong>Monthly Rate:</strong> ₹{{ ad.price }} / month</p>
+                {% else %}
+                    <p class="mt-2 text-gray-600"><strong>Price:</strong> ₹{{ ad.price }}</p>
+                {% endif %}
+                <p class="mt-2 text-gray-600"><strong>Posted on:</strong> {{ ad.created_at|date:"F j, Y" }}</p>
             </div>
-        {% else %}
-            <form method="POST">
-                {% csrf_token %}
-                <div class="flex mt-6">
-                    <button type="submit" class="p-3 rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition duration-300 shadow-md">
-                        <i class="fas fa-envelope"></i> Send Message
-                    </button>
-                </div>
-            </form>
-        {% endif %}
-    {% endif %}
+            <div>
+                <p class="mt-2 text-gray-600"><strong>Posted by:</strong> {{ ad.user.username }}</p>
+                {% if ad.category.name == 'Events' or ad.category.name == 'Classes' %}
+                    <p class="mt-2 text-gray-600"><strong>Event Start:</strong> {{ ad.event_start_date }}</p>
+                    <p class="mt-2 text-gray-600"><strong>Event End:</strong> {{ ad.event_end_date }}</p>
+                {% endif %}
+            </div>
+        </div>
+        {% if ad.show_contact_info %}
+            <hr class="my-4">
 
+            <h2 class="text-lg font-bold text-gray-800">Contact Info:</h2>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-2">
+                <p class="mt-4 text-gray-600"><strong>Contact Info:</strong> {{ ad.contact_info }}</p>
+            </div>
+        {% endif %}
+    </div>
+
+    {% if user.is_authenticated and ad.user != user %}
+        <form method="POST" class="mt-6">
+            {% csrf_token %}
+            <div class="flex">
+                <button type="submit" class="p-3 rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition duration-300 shadow-md">
+                    <i class="fas fa-envelope"></i> Send Message
+                </button>
+            </div>
+        </form>
+    {% endif %}
+    
 </div>
 {% endblock %}

--- a/ads/templates/ads/ad_detail.html
+++ b/ads/templates/ads/ad_detail.html
@@ -1,5 +1,9 @@
 {% extends 'base.html' %}
 
+{% block extra_head %}
+    {% include "ads/ad_like_scripts.html" %}
+{% endblock %}
+
 {% block content %}
 <div class="container mx-auto mt-8">
 
@@ -33,30 +37,49 @@
         <p class="mt-2 text-gray-600"><strong>Event End:</strong> {{ ad.event_end_date }}</p>
     {% endif %}
 
-    <div class="mt-6 flex space-x-4">
-        <button type="button" class="px-4 py-2 bg-green-500 text-white rounded hover:bg-green-600 transition duration-200">Like</button>
-    </div>
-
     {% if user.is_authenticated %}
-    {% if ad.user == user %}
-        <div class="mt-6 flex space-x-4">
-            <a href="{% url 'ads:ad_edit' category_slug=ad.category.slug ad_slug=ad.slug %}" class="px-4 py-2 bg-red-500 text-white rounded hover:bg-red-600 transition duration-200">
-                Edit
+        <div x-data="likeComponent({{ user_has_liked|lower }}, {{ ad.total_likes }}, '{{ csrf_token }}')" class="flex flex-col items-center justify-end text-right">
+        
+            <a @click="likeAd('{{ ad.category.slug }}', '{{ ad.slug }}')" class="inline-flex items-center justify-end mt-2 p-2 rounded-full hover:bg-gray-200 transition duration-200">
+                
+                <template x-if="liked">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 text-red-500" fill="currentColor" viewBox="0 0 24 24" stroke="none">
+                        <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
+                    </svg>
+                </template>
+                <template x-if="!liked">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z" />
+                    </svg>
+                </template>
+
             </a>
-            <a href="{% url 'ads:ad_delete' category_slug=ad.category.slug ad_slug=ad.slug %}" class="px-4 py-2 bg-red-500 text-white rounded hover:bg-red-600 transition duration-200">
-                Delete
-            </a>
+            
+            <p class="text-sm text-gray-600">
+                <span x-text="totalLikes"></span>
+            </p>
         </div>
-    {% else %}
-    <form method="POST">
-        {% csrf_token %}
-        <div class="flex items-center space-x-2 mt-6">
-            <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition duration-300 shadow-md">
-                Send Message
-            </button>
-        </div>
-    </form>
-    {% endif %}
+
+        {% if ad.user == user %}
+            <div class="mt-6 flex justify-around">
+                <a href="{% url 'ads:ad_edit' category_slug=ad.category.slug ad_slug=ad.slug %}" class="p-3 rounded-lg bg-red-500 text-white hover:bg-red-600 transition duration-200">
+                    <i class="fas fa-edit"></i> Edit
+                </a>
+
+                <a href="{% url 'ads:ad_delete' category_slug=ad.category.slug ad_slug=ad.slug %}" class="p-3 rounded-lg bg-red-500 text-white hover:bg-red-600 transition duration-200">
+                    <i class="fas fa-trash-alt"></i> Delete
+                </a>
+            </div>
+        {% else %}
+            <form method="POST">
+                {% csrf_token %}
+                <div class="flex mt-6">
+                    <button type="submit" class="p-3 rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition duration-300 shadow-md">
+                        <i class="fas fa-envelope"></i> Send Message
+                    </button>
+                </div>
+            </form>
+        {% endif %}
     {% endif %}
 
 </div>

--- a/ads/templates/ads/ad_like_scripts.html
+++ b/ads/templates/ads/ad_like_scripts.html
@@ -1,0 +1,23 @@
+<script>
+    document.addEventListener('alpine:init', () => {
+        Alpine.data('likeComponent', (userHasLiked, totalLikes, csrfToken) => ({
+            liked: userHasLiked,
+            totalLikes: totalLikes,
+            likeAd(adCategorySlug, adSlug) {
+                const url = `/category/${adCategorySlug}/ads/${adSlug}/like/`;
+                fetch(url, {
+                    method: 'POST',
+                    headers: {
+                        'X-CSRFToken': csrfToken,
+                        'Content-Type': 'application/json',
+                    },
+                })
+                .then(response => response.json())
+                .then(data => {
+                    this.liked = data.liked;
+                    this.totalLikes = data.total_likes;
+                });
+            }
+        }));
+    });    
+</script>

--- a/ads/templates/base.html
+++ b/ads/templates/base.html
@@ -7,6 +7,8 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>{% block title %}Classifieds{% endblock %}</title>
 
+    <script src="https://unpkg.com/@heroicons/vue@v2.0.11"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
     {% block extra_head %}{% endblock %}

--- a/ads/tests.py
+++ b/ads/tests.py
@@ -1000,3 +1000,74 @@ class AdDetailTemplateTests(TestCase):
 
         self.assertNotContains(response, 'Edit')
         self.assertNotContains(response, 'Delete')
+
+
+class AdLikeViewTests(TestCase):
+
+    def setUp(self):
+        self.user = User.objects.create_user(username='testuser', password='password')
+        self.category = Category.objects.create(name='Test Category', slug='test-category')
+        self.ad = Ads.objects.create(
+            title="Original Title", 
+            category=self.category,
+            description="Original description", 
+            price=100.00, 
+            tags='test',
+            contact_info='original@example.com',
+            postal_code='638056',
+            image='test.jpeg',
+            location="Original Location",
+            user=self.user,
+            total_likes=0  
+        )
+        self.like_url = reverse('ads:ad_like', kwargs={'category_slug': self.ad.category.slug, 'ad_slug': self.ad.slug})
+
+    def test_like_ad_authenticated_user(self):
+        self.client.login(username='testuser', password='password')
+        response = self.client.post(self.like_url, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        self.assertEqual(response.status_code, 200)
+        self.ad.refresh_from_db()
+        self.assertTrue(self.ad.users_like.filter(id=self.user.id).exists())
+        self.assertEqual(response.json()['liked'], True)
+        self.assertEqual(response.json()['total_likes'], 1)
+
+    def test_unlike_ad_authenticated_user(self):
+        self.ad.users_like.add(self.user)
+        self.ad.total_likes += 1
+        self.ad.save()
+        
+        self.client.login(username='testuser', password='password')
+        response = self.client.post(self.like_url, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        self.assertEqual(response.status_code, 200)
+        self.ad.refresh_from_db()
+        self.assertFalse(self.ad.users_like.filter(id=self.user.id).exists())
+        self.assertEqual(response.json()['liked'], False)
+        self.assertEqual(response.json()['total_likes'], 0)
+
+    def test_like_ad_unauthenticated_user(self):
+        response = self.client.post(self.like_url, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        self.assertEqual(response.status_code, 302)
+
+    def test_like_ad_total_likes(self):
+        self.client.login(username='testuser', password='password')
+        response = self.client.post(self.like_url, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        self.ad.refresh_from_db()
+        self.assertEqual(self.ad.users_like.count(), 1)
+        self.assertEqual(response.json()['total_likes'], 1)
+
+    def test_unlike_ad_total_likes_decrease(self):
+        self.ad.users_like.add(self.user)
+        self.ad.total_likes += 1
+        self.ad.save()
+        
+        self.client.login(username='testuser', password='password')
+        response = self.client.post(self.like_url, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        self.ad.refresh_from_db()
+        self.assertEqual(self.ad.users_like.count(), 0)
+        self.assertEqual(response.json()['total_likes'], 0)
+
+    def test_invalid_ad_slug(self):
+        self.client.login(username='testuser', password='password')
+        invalid_like_url = reverse('ads:ad_like', kwargs={'category_slug': 'gigs', 'ad_slug': 'invalid-slug'})
+        response = self.client.post(invalid_like_url, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        self.assertEqual(response.status_code, 404)

--- a/ads/urls.py
+++ b/ads/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
     path('category/<slug:category_slug>/ads/<slug:ad_slug>/edit/', views.AdEditView.as_view( ), name='ad_edit'),
     path('category/<slug:category_slug>/ads/<slug:ad_slug>/delete/', views.AdDeleteView.as_view( ), name='ad_delete'),
     path('category/<slug:category_slug>/ads/<slug:ad_slug>/like/', views.AdLikeView.as_view() , name='ad_like'),
+    path('category/<slug:category_slug>/ads/<slug:ad_slug>/toggle_contact_info/', views.AdToggleContactInfo.as_view() , name='toggle_contact_info'),
 
     path('ad/new/', views.AdCreateView.as_view(), name='ad_create') ,
 

--- a/ads/urls.py
+++ b/ads/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     path('category/<slug:category_slug>/ads/<slug:ad_slug>/detail/', views.AdDetailView.as_view(), name='ad_detail'),
     path('category/<slug:category_slug>/ads/<slug:ad_slug>/edit/', views.AdEditView.as_view( ), name='ad_edit'),
     path('category/<slug:category_slug>/ads/<slug:ad_slug>/delete/', views.AdDeleteView.as_view( ), name='ad_delete'),
+    path('category/<slug:category_slug>/ads/<slug:ad_slug>/like/', views.AdLikeView.as_view() , name='ad_like'),
 
     path('ad/new/', views.AdCreateView.as_view(), name='ad_create') ,
 

--- a/ads/views.py
+++ b/ads/views.py
@@ -159,3 +159,15 @@ class AdLikeView(LoginRequiredMixin, View):
             'liked': liked,
             'total_likes': ad.total_likes,
         })
+
+
+class AdToggleContactInfo(LoginRequiredMixin, View):
+    def post(self, request, category_slug, ad_slug, *args, **kwargs):
+        ad = get_object_or_404(Ads, category__slug=category_slug, slug=ad_slug)
+
+        show_contact_info = request.POST.get('show_contact_info') == 'True'
+        ad.show_contact_info = not show_contact_info  
+        ad.save()
+
+        return redirect('ads:ad_detail', category_slug=ad.category.slug, ad_slug=ad.slug)
+    

--- a/ads/views.py
+++ b/ads/views.py
@@ -8,6 +8,7 @@ from django.urls import reverse_lazy
 from django.http import HttpResponseForbidden
 from functools import wraps
 from django.views import View
+from django.http import JsonResponse
 
 
 class HomeView(ListView):
@@ -40,6 +41,12 @@ class AdDetailView(DetailView):
 
     def get_object(self):
         return get_object_or_404(Ads, slug=self.kwargs['ad_slug'], category__slug=self.kwargs['category_slug'])
+    
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        ad = self.get_object()
+        context['user_has_liked'] = self.request.user in ad.users_like.all()
+        return context
     
     def post(self, request, *args, **kwargs):
 
@@ -132,3 +139,23 @@ class AdDeleteView(LoginRequiredMixin, DeleteView):
     def get(self, request, *args, **kwargs):
         return super().get(request, *args, **kwargs)
 
+
+class AdLikeView(LoginRequiredMixin, View):
+    def post(self, request, category_slug, ad_slug, *args, **kwargs):
+        ad = get_object_or_404(Ads, category__slug=category_slug, slug=ad_slug)
+
+        if request.user in ad.users_like.all():
+            ad.users_like.remove(request.user)
+            ad.total_likes -= 1
+            ad.save()
+            liked = False
+        else:
+            ad.users_like.add(request.user)
+            liked = True
+            ad.total_likes += 1
+            ad.save()
+
+        return JsonResponse({
+            'liked': liked,
+            'total_likes': ad.total_likes,
+        })


### PR DESCRIPTION
### PR Description

#### Overview
This pull request introduces functionality that enables authenticated users to like and unlike ads within the application. Additionally, authenticated users who posted the ad can toggle the visibility of contact information for ads. This enhances user engagement and improves the overall experience on the platform.

#### Features

- **Like an Ad**: Authenticated users can like an ad. Upon liking, the ad's total likes count is incremented, and the user's like is recorded.
  
- **Unlike an Ad**: Users can unlike an ad, which decrements the total likes count and removes their like from the ad.

- **Show/Hide Contact Info**: Authenticated user who posted the ad can toggle the visibility of contact information associated with each ad, enhancing user interaction and information access.

- **Dynamic Response**: The like/unlike action responds with a JSON object indicating the current like status and total likes count, enabling a seamless user experience without full page reloads.


